### PR TITLE
Add workflow to deploy to GHP

### DIFF
--- a/.github/deploy-to-ghp/action.yml
+++ b/.github/deploy-to-ghp/action.yml
@@ -1,0 +1,37 @@
+name: Deploy to GitHub Pages
+
+author: Gabriel Montes
+
+description: Deploy a directory to GitHub Pages
+
+inputs:
+  build-with-npm:
+    description: Run NPM build script before deploying
+    default: "true"
+  publish-dir:
+    description: Directory to publish
+    default: public
+
+outputs:
+  page_url:
+    description: The URL of the deployed page
+    value: ${{ steps.deployment.outputs.page_url }}
+
+runs:
+  using: composite
+  steps:
+    - if: ${{ inputs.build-with-npm == 'true' }}
+      uses: hemilabs/actions/setup-node-env@v1
+    - run: npm run --if-present build
+      shell: sh
+      if: ${{ inputs.build-with-npm == 'true' }}
+    - uses: actions/configure-pages@v5
+    - uses: actions/upload-pages-artifact@v3
+      with:
+        path: ${{ inputs.publish-dir }}
+    - id: deployment
+      uses: actions/deploy-pages@v4
+
+branding:
+  color: orange
+  icon: book-open

--- a/.github/workflows/ghp-deploy.yml
+++ b/.github/workflows/ghp-deploy.yml
@@ -1,0 +1,35 @@
+name: GitHub Pages Deployment
+
+on:
+  workflow_dispatch:
+  workflow_run:
+    branches:
+      - master
+    types:
+      - completed
+    workflows:
+      - JS Checks
+
+permissions:
+  id-token: write
+  pages: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: deployment
+        uses: ./.github/actions/deploy-to-ghp
+        with:
+          build-with-npm: "true"
+          publish-dir: website/dist
+    timeout-minutes: 2


### PR DESCRIPTION
It will trigger on merges to `master` and after `JS Checks` completes.

If https://github.com/hemilabs/actions/pull/24 is ever merged, we could use that instead of the action added in this PR.