### PR TITLE
Ensure the build script is run in all workspaces

### DIFF
--- a/.github/actions/deploy-to-ghp/action.yml
+++ b/.github/actions/deploy-to-ghp/action.yml
@@ -22,7 +22,7 @@ runs:
   steps:
     - if: ${{ inputs.build-with-npm == 'true' }}
       uses: hemilabs/actions/setup-node-env@v1
-    - run: npm run --if-present build
+    - run: npm run --if-present --workspaces build
       shell: sh
       if: ${{ inputs.build-with-npm == 'true' }}
     - uses: actions/configure-pages@v5


### PR DESCRIPTION
The action added in #6 expected the "build" NPM script to be defined in the root `package.json`. We are using workspaces here and the script should be called for the website instead. This PR fixes that.