### PR TITLE
Set the base URL for Vite

### DIFF
--- a/website/vite.config.ts
+++ b/website/vite.config.ts
@@ -3,5 +3,6 @@ import { defineConfig } from "vite";
 import tsconfigPaths from "vite-tsconfig-paths";
 
 export default defineConfig({
+  base: process.env.GITHUB_ACTIONS ? "/tge-mint-page/" : "/",
   plugins: [react(), tsconfigPaths()],
 });


### PR DESCRIPTION
Last config item to make #6 fully work! 🤞🏼 

When building inside GitHub Actions, the base should be set to the name of the repo. Otherwise, i.e. when running locally, it should be set to `/`. 

Ref: See the [reference to the environment variables](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#default-environment-variables) automatically set in GitHub Actions.