### PR TITLE
Build site in the workflow

### DIFF
--- a/.github/actions/deploy-to-ghp/action.yml
+++ b/.github/actions/deploy-to-ghp/action.yml
@@ -8,9 +8,6 @@ inputs:
   artifact-name:
     description: Base name for the artifact
     default: github-pages
-  build-with-npm:
-    description: Run NPM build script before deploying
-    default: "true"
   publish-dir:
     description: Directory to publish
     default: public
@@ -23,11 +20,6 @@ outputs:
 runs:
   using: composite
   steps:
-    - if: ${{ inputs.build-with-npm == 'true' }}
-      uses: hemilabs/actions/setup-node-env@v1
-    - run: npm run --if-present --workspaces build
-      shell: sh
-      if: ${{ inputs.build-with-npm == 'true' }}
     - uses: actions/configure-pages@v5
     - uses: actions/upload-pages-artifact@v3
       with:

--- a/.github/workflows/ghp-deploy.yml
+++ b/.github/workflows/ghp-deploy.yml
@@ -27,9 +27,15 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@v4
+      - uses: hemilabs/actions/setup-node-env@v1
+      - id: build
+        run: npm run --workspaces build
+        env:
+          VITE_WALLET_CONNECT_PROJECT_ID: ${{ vars.VITE_WALLET_CONNECT_PROJECT_ID }}
+          VITE_WALLET_CONNECT_PROJECT_NAME: ${{ vars.VITE_WALLET_CONNECT_PROJECT_NAME }}
       - id: deployment
         uses: ./.github/actions/deploy-to-ghp
         with:
-          build-with-npm: "true"
+          artifact-name: github-pages-${{ github.run_id }}
           publish-dir: website/dist
     timeout-minutes: 2

--- a/.github/workflows/ghp-deploy.yml
+++ b/.github/workflows/ghp-deploy.yml
@@ -36,6 +36,5 @@ jobs:
       - id: deployment
         uses: ./.github/actions/deploy-to-ghp
         with:
-          artifact-name: github-pages-${{ github.run_id }}
           publish-dir: website/dist
     timeout-minutes: 2


### PR DESCRIPTION
If we build the site in the main workflow, we can include/inject the environment variables required for Wallet Connect to work. As the filesystem/context is maintained across different steps in the same job, once the site is built, it should be picked up by the steps in the reusable action which will upload the artifact to GitHub Pages. At least that's the theory and Copilot says I'm right 🤷🏼‍♂️ 