### PR TITLE
Run the build inside website

### DIFF
--- a/.github/workflows/ghp-deploy.yml
+++ b/.github/workflows/ghp-deploy.yml
@@ -28,8 +28,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: hemilabs/actions/setup-node-env@v1
-      - id: build
-        run: npm run --workspaces build
+      - run: cd website && npm run build
         env:
           VITE_WALLET_CONNECT_PROJECT_ID: ${{ vars.VITE_WALLET_CONNECT_PROJECT_ID }}
           VITE_WALLET_CONNECT_PROJECT_NAME: ${{ vars.VITE_WALLET_CONNECT_PROJECT_NAME }}


### PR DESCRIPTION
When running `npm run --workspaces <script>`, if any workspace does not have the named script, the command exits with an error. We could either run it with `--if-present` or, much simpler, just move into `website` and run the build process there.