### PR TITLE
Fix images broken to relative path

### DIFF
--- a/website/src/components/background.tsx
+++ b/website/src/components/background.tsx
@@ -1,7 +1,7 @@
 export const Background = () => (
   <img
     alt="Background"
-    src="/background.png"
+    src="./background.png"
     className="pointer-events-none fixed left-0 top-0 -z-10 h-screen w-screen object-cover"
   />
 );

--- a/website/src/components/hemiLogo.tsx
+++ b/website/src/components/hemiLogo.tsx
@@ -20,7 +20,7 @@ export const HemiLogoFull = (props: ComponentProps<"img">) => (
   <img
     alt="Hemi Logo"
     height={28}
-    src="/hemiLogoFull.svg"
+    src="./hemiLogoFull.svg"
     width={78}
     {...props}
   />

--- a/website/src/components/step/positionStatus.tsx
+++ b/website/src/components/step/positionStatus.tsx
@@ -24,7 +24,7 @@ export const PositionStatus = function ({ position, status }: Props) {
           alt="Loading icon"
           className="animate-spin"
           height={20}
-          src="/gradientLoading.png"
+          src="./gradientLoading.png"
           width={20}
         />
       )}


### PR DESCRIPTION
The images are broken on prod env, where the page is deployed in a subpath

This PR fixes this

<img width="1907" alt="image" src="https://github.com/user-attachments/assets/ad2cd2e8-1d06-444d-a561-2cdcada96b19" />


Note the subpath I added locally